### PR TITLE
여러 클라이언트 로그인 고려

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.3.1",
         "@nestjs/jwt": "^10.2.0",
-        "@nestjs/microservices": "^10.3.1",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.3.1",
         "@prisma/client": "^5.8.1",
@@ -26,7 +25,8 @@
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.2.0"
+        "rxjs": "^7.2.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.3.0",
@@ -39,6 +39,7 @@
         "@types/node": "18.11.18",
         "@types/passport-local": "^1.0.38",
         "@types/supertest": "^2.0.11",
+        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "cross-env": "^7.0.3",
@@ -1871,6 +1872,14 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.1.tgz",
@@ -1924,6 +1933,8 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.3.1.tgz",
       "integrity": "sha512-wGdQUcfgmEYGj5mgSMRl3l0szNFtkHZFqKIRJpo4QHeawTZd9rPXbN0I9+0qEDzltvApjX5Bj+8vLuej9fH42A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.6.2"
@@ -2529,6 +2540,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.11.8",
@@ -9005,9 +9022,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10644,6 +10665,13 @@
         "dotenv-expand": "10.0.0",
         "lodash": "4.17.21",
         "uuid": "9.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
       }
     },
     "@nestjs/core": {
@@ -10672,6 +10700,8 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.3.1.tgz",
       "integrity": "sha512-wGdQUcfgmEYGj5mgSMRl3l0szNFtkHZFqKIRJpo4QHeawTZd9rPXbN0I9+0qEDzltvApjX5Bj+8vLuej9fH42A==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "iterare": "1.2.1",
         "tslib": "2.6.2"
@@ -11166,6 +11196,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "@types/validator": {
       "version": "13.11.8",
@@ -15935,9 +15971,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.3.1",
     "@nestjs/jwt": "^10.2.0",
-    "@nestjs/microservices": "^10.3.1",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.3.1",
     "@prisma/client": "^5.8.1",
@@ -37,7 +36,8 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.3.0",
@@ -50,6 +50,7 @@
     "@types/node": "18.11.18",
     "@types/passport-local": "^1.0.38",
     "@types/supertest": "^2.0.11",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "cross-env": "^7.0.3",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,19 +1,17 @@
-import { Body, Controller, Inject, Post, Res } from '@nestjs/common'
-import { ClientRedis } from '@nestjs/microservices'
-import { Redis } from 'ioredis'
+import { Body, Controller, Post, Res } from '@nestjs/common'
 import { Response } from 'express'
 
-import { ACCESS_TOKEN_EXPIRATION_TIME, REFRESH_TOKEN_EXPIRATION_TIME, REFRESH_TOKEN_REDIS_KEY } from './constants'
+import { ACCESS_TOKEN_EXPIRATION_TIME, REFRESH_TOKEN_EXPIRATION_TIME } from './constants'
 import { LoginRequestDto } from './dto'
 import { AuthService } from './auth.service'
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService, @Inject('REDIS_SERVICE') private client: ClientRedis) {}
+  constructor(private readonly authService: AuthService) {}
 
   @Post('login')
   async login(@Body() dto: LoginRequestDto, @Res({ passthrough: true }) res: Response): Promise<void> {
-    const { access_token, refresh_token, user_id } = await this.authService.login(dto)
+    const { access_token, refresh_token } = await this.authService.login(dto)
 
     // token들 cookie로 설정
     res.cookie('access_token', access_token, {
@@ -32,9 +30,5 @@ export class AuthController {
       //   domain: '', // TODO: 배포 시 `.루트 도메인` 설정
       path: '/',
     })
-
-    // redis에 refresh token 저장
-    const client: Redis = this.client.createClient()
-    client.set(`${REFRESH_TOKEN_REDIS_KEY}:${user_id}`, refresh_token, 'PX', REFRESH_TOKEN_EXPIRATION_TIME)
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,27 +1,14 @@
 import { Module } from '@nestjs/common'
-import { ClientsModule, Transport } from '@nestjs/microservices'
 import { JwtModule } from '@nestjs/jwt'
 
 import { UsersModule } from 'src/users/users.module'
 import { AuthService } from './auth.service'
 import { AuthController } from './auth.controller'
+import { RefreshTokenRepository } from './refresh-token.repository'
 
 @Module({
-  imports: [
-    UsersModule,
-    JwtModule.register({ secret: process.env.JWT_SECRET }),
-    ClientsModule.register([
-      {
-        name: 'REDIS_SERVICE',
-        transport: Transport.REDIS,
-        options: {
-          host: process.env.REDIS_HOST,
-          port: parseInt(process.env.REDIS_PORT, 10),
-        },
-      },
-    ]),
-  ],
-  providers: [AuthService],
+  imports: [UsersModule, JwtModule.register({ secret: process.env.JWT_SECRET })],
+  providers: [AuthService, RefreshTokenRepository],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -18,8 +18,8 @@ export class AuthService {
   ) {}
 
   /** redis에 refresh token 저장 */
-  private async storeRefreshToken(refresh_token: string, userId: number, clientId: string) {
-    this.refreshTokenRepository.set(
+  private async storeRefreshToken(refresh_token: string, userId: number, clientId: string): Promise<void> {
+    await this.refreshTokenRepository.set(
       `${REFRESH_TOKEN_REDIS_KEY}:${userId}:${clientId}`,
       refresh_token,
       REFRESH_TOKEN_EXPIRATION_TIME,
@@ -27,7 +27,7 @@ export class AuthService {
   }
 
   /** user id 당 토큰 개수를 제한할 수 있도록 최대 개수를 넘었을 때 오래된 토큰을 제거하는 함수 */
-  private async maintainTokenCount(userId: number) {
+  private async maintainTokenCount(userId: number): Promise<void> {
     const refreshTokens = await this.refreshTokenRepository.getTTLsByPattern(`${REFRESH_TOKEN_REDIS_KEY}:${userId}:*`)
 
     // ttl 기준으로 정렬

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,13 +1,45 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common'
-import * as bcrypt from 'bcrypt'
 import { JwtService } from '@nestjs/jwt'
+import * as bcrypt from 'bcrypt'
+import * as dayjs from 'dayjs'
+import { v4 as uuidv4 } from 'uuid'
+
 import { UsersRepository } from 'src/users/users.repository'
 import { AuthTokensDto, LoginRequestDto } from './dto'
-import * as dayjs from 'dayjs'
+import { RefreshTokenRepository } from './refresh-token.repository'
+import { MAX_CLIENT_TOKEN_COUNT, REFRESH_TOKEN_EXPIRATION_TIME, REFRESH_TOKEN_REDIS_KEY } from './constants'
 
 @Injectable()
 export class AuthService {
-  constructor(private readonly usersRepository: UsersRepository, private jwtService: JwtService) {}
+  constructor(
+    private readonly usersRepository: UsersRepository,
+    private readonly jwtService: JwtService,
+    private readonly refreshTokenRepository: RefreshTokenRepository,
+  ) {}
+
+  /** redis에 refresh token 저장 */
+  private async storeRefreshToken(refresh_token: string, userId: number, clientId: string) {
+    this.refreshTokenRepository.set(
+      `${REFRESH_TOKEN_REDIS_KEY}:${userId}:${clientId}`,
+      refresh_token,
+      REFRESH_TOKEN_EXPIRATION_TIME,
+    )
+  }
+
+  /** user id 당 토큰 개수를 제한할 수 있도록 최대 개수를 넘었을 때 오래된 토큰을 제거하는 함수 */
+  private async maintainTokenCount(userId: number) {
+    const refreshTokens = await this.refreshTokenRepository.getTTLsByPattern(`${REFRESH_TOKEN_REDIS_KEY}:${userId}:*`)
+
+    // ttl 기준으로 정렬
+    refreshTokens.sort((a, b) => a.ttl - b.ttl)
+
+    // user id 당 최대 10개의 refresh token 유지
+    if (refreshTokens.length > MAX_CLIENT_TOKEN_COUNT) {
+      const keysToDelete = refreshTokens.slice(0, -MAX_CLIENT_TOKEN_COUNT)
+      // 가장 오래된 refresh token부터 삭제
+      await this.refreshTokenRepository.del(keysToDelete.map(({ key }) => key))
+    }
+  }
 
   async login({ email, password }: LoginRequestDto): Promise<AuthTokensDto> {
     const user = await this.usersRepository.findByEmail(email)
@@ -22,20 +54,27 @@ export class AuthService {
       throw new UnauthorizedException('Invalid email or password')
     }
 
+    const clientId = uuidv4()
+    const refreshToken = this.jwtService.sign({
+      sub: user.id,
+      jti: clientId,
+      iat: dayjs().unix(),
+      exp: dayjs().add(7, 'day').unix(),
+    })
+
+    await this.storeRefreshToken(refreshToken, user.id, clientId)
+    await this.maintainTokenCount(user.id)
+
     // TODO: iss - 서버 배포 시 루트 도메인 사용
     return {
-      user_id: user.id,
       access_token: this.jwtService.sign({
         sub: user.id,
+        jti: clientId,
         iat: dayjs().unix(),
         exp: dayjs().add(1, 'hour').unix(),
         user_role: user.role,
       }),
-      refresh_token: this.jwtService.sign({
-        sub: user.id,
-        iat: dayjs().unix(),
-        exp: dayjs().add(7, 'day').unix(),
-      }),
+      refresh_token: refreshToken,
     }
   }
 }

--- a/src/auth/constants/auth.constants.ts
+++ b/src/auth/constants/auth.constants.ts
@@ -1,14 +1,11 @@
-/**
- * access_token 만료시간, 1hour, ms단위
- */
+/** access_token 만료시간, 1hour, ms단위 */
 export const ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 1000
 
-/**
- * refresh_token 만료시간, 7day, ms단위
- */
+/** refresh_token 만료시간, 7day, ms단위 */
 export const REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000
 
-/**
- * refresh_token redis key
- */
+/** refresh_token redis key */
 export const REFRESH_TOKEN_REDIS_KEY = 'refresh-token'
+
+/** user id 당 최대 유지 가능한 토큰 개수 */
+export const MAX_CLIENT_TOKEN_COUNT = 10

--- a/src/auth/dto/auth-toknes.dto.ts
+++ b/src/auth/dto/auth-toknes.dto.ts
@@ -1,6 +1,4 @@
 export class AuthTokensDto {
-  public user_id: number
-
   public access_token: string
 
   public refresh_token: string

--- a/src/auth/refresh-token.repository.ts
+++ b/src/auth/refresh-token.repository.ts
@@ -47,6 +47,7 @@ export class RefreshTokenRepository {
       keys.map(async (key) => {
         const ttl = await this.redisClient.ttl(key)
 
+        // ttl이 설정되지 않았거나(-1), 존재하지 않는 key일 경우(-2)
         if (ttl === -1 || ttl === -2) return null
         return { key, ttl }
       }),

--- a/src/auth/refresh-token.repository.ts
+++ b/src/auth/refresh-token.repository.ts
@@ -1,0 +1,57 @@
+import Redis, { RedisKey } from 'ioredis'
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class RefreshTokenRepository {
+  private readonly redisClient: Redis
+
+  constructor() {
+    this.redisClient = new Redis({
+      host: process.env.REDIS_HOST,
+      port: parseInt(process.env.REDIS_PORT, 10),
+    })
+  }
+
+  /** key value 생성 */
+  async set(key: string, value: string, ms?: number): Promise<'OK'> {
+    if (!!ms) {
+      return this.redisClient.set(key, value, 'PX', ms)
+    }
+    return this.redisClient.set(key, value)
+  }
+
+  /** key들에 해당하는 모든 value 삭제 */
+  async del(keys: RedisKey[]): Promise<number> {
+    return this.redisClient.del(keys)
+  }
+
+  /** pattern에 맞는 모든 key 조회 */
+  private async getKeysByPattern(pattern: string): Promise<RedisKey[]> {
+    let cursor = '0'
+    let keys: RedisKey[] = []
+
+    do {
+      const reply = await this.redisClient.scan(cursor, 'MATCH', pattern)
+      cursor = reply[0]
+      keys = keys.concat(reply[1])
+    } while (cursor !== '0')
+
+    return keys
+  }
+
+  /** pattern에 맞는 모든 key의 모든 ttl 조회 */
+  async getTTLsByPattern(pattern: string): Promise<{ key: RedisKey; ttl: number }[]> {
+    const keys = await this.getKeysByPattern(pattern)
+
+    const results = await Promise.all(
+      keys.map(async (key) => {
+        const ttl = await this.redisClient.ttl(key)
+
+        if (ttl === -1 || ttl === -2) return null
+        return { key, ttl }
+      }),
+    )
+
+    return results.filter((value) => !!value)
+  }
+}

--- a/src/auth/refresh-token.repository.ts
+++ b/src/auth/refresh-token.repository.ts
@@ -13,11 +13,8 @@ export class RefreshTokenRepository {
   }
 
   /** key value 생성 */
-  async set(key: string, value: string, ms?: number): Promise<'OK'> {
-    if (ms) {
-      return this.redisClient.set(key, value, 'PX', ms)
-    }
-    return this.redisClient.set(key, value)
+  async set(key: string, value: string, ms: number): Promise<'OK'> {
+    return this.redisClient.set(key, value, 'PX', ms)
   }
 
   /** key들에 해당하는 모든 value 삭제 */

--- a/src/auth/refresh-token.repository.ts
+++ b/src/auth/refresh-token.repository.ts
@@ -14,7 +14,7 @@ export class RefreshTokenRepository {
 
   /** key value 생성 */
   async set(key: string, value: string, ms?: number): Promise<'OK'> {
-    if (!!ms) {
+    if (ms) {
       return this.redisClient.set(key, value, 'PX', ms)
     }
     return this.redisClient.set(key, value)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,19 +3,9 @@ import { ValidationPipe } from '@nestjs/common'
 import * as cookieParser from 'cookie-parser'
 
 import { AppModule } from './app.module'
-import { Transport } from '@nestjs/microservices'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
-
-  app.connectMicroservice({
-    transport: Transport.REDIS,
-    options: {
-      host: process.env.REDIS_HOST,
-      port: parseInt(process.env.REDIS_PORT, 10),
-    },
-  })
-  await app.startAllMicroservices()
 
   app.useGlobalPipes(new ValidationPipe({ transform: true }))
   app.use(cookieParser())


### PR DESCRIPTION
# 변경사항
- 로그인 시 uuid 식별자를 이용하여 여러 클라이언트에서 로그인이 가능하도록 변경
  - access token payload에 jti claim 정의
    - 특정 세션을 무효화해야 할 경우 jti에 저장된 식별자를 이용하여 무효화할 수 있도록 함
  - refresh token payload에 jti claim 정의
    - 특정 세션을 무효화하거나, 로그아웃 시 해당 식별자를 이용하여 redis 데이터를 삭제할 수 있도록 함
  - user id 당 redis에 저장되는 토큰 개수를 제한
    - 만약 무분별하게 로그인 api가 호출될 경우 해당 user id에 해당하는 토큰이 무한증식할 수 있기 때문에, user id 당 사용할 수 있는 최대 토큰 개수(세션)를 제한함
  - RefreshTokenRepository 정의 및 AuthService 레이어에서 사용