### PR TITLE
프로젝트 도메인 관련 schema 정의

### DIFF
--- a/prisma/migrations/20240303095153_add_project_category_table/migration.sql
+++ b/prisma/migrations/20240303095153_add_project_category_table/migration.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE `project_category` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(12) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20240303095414_add_project_table/migration.sql
+++ b/prisma/migrations/20240303095414_add_project_table/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE `project` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `status` ENUM('REVIEW_PENDING', 'REVIEW_PASSED', 'REVIEW_FAILED', 'PROJECT_CANCELED', 'FUNDING_OPENED', 'FUNDING_SUCCESS', 'FUNDING_FAILURE', 'FUNDING_CANCELED', 'SETTLEMENT_COMPLETED', 'PROJECT_HALTED') NOT NULL,
+    `title` VARCHAR(32) NOT NULL,
+    `summary` VARCHAR(50) NOT NULL,
+    `description` MEDIUMTEXT NOT NULL,
+    `thumbnail_url` VARCHAR(2000) NOT NULL,
+    `target_amount` BIGINT NOT NULL,
+    `collected_amount` BIGINT NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `created_by_id` INTEGER NOT NULL,
+    `category_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `project` ADD CONSTRAINT `project_created_by_id_fkey` FOREIGN KEY (`created_by_id`) REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `project` ADD CONSTRAINT `project_category_id_fkey` FOREIGN KEY (`category_id`) REFERENCES `project_category`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240303095600_add_project_schedule_table/migration.sql
+++ b/prisma/migrations/20240303095600_add_project_schedule_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE `project_schedule` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `type` ENUM('FUNDING_START_DATE', 'FUNDING_DUE_DATE', 'PAYMENT_DUE_DATE', 'PAYMENT_SETTLEMENT_DATE') NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `project_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `project_schedule` ADD CONSTRAINT `project_schedule_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240303095828_add_project_reword_table/migration.sql
+++ b/prisma/migrations/20240303095828_add_project_reword_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `project_reword` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(50) NOT NULL,
+    `description` VARCHAR(200) NOT NULL,
+    `amount` INTEGER NOT NULL,
+    `limit` INTEGER NOT NULL,
+    `expected_delivery_date` DATETIME(3) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `project_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `project_reword` ADD CONSTRAINT `project_reword_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240303100213_add_sponsorship_table/migration.sql
+++ b/prisma/migrations/20240303100213_add_sponsorship_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE `sponsorship` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `project_id` INTEGER NOT NULL,
+    `created_by_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `sponsorship` ADD CONSTRAINT `sponsorship_project_id_fkey` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `sponsorship` ADD CONSTRAINT `sponsorship_created_by_id_fkey` FOREIGN KEY (`created_by_id`) REFERENCES `user`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240303100656_add_sponsorship_reword_table/migration.sql
+++ b/prisma/migrations/20240303100656_add_sponsorship_reword_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `sponsorship_reword` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `count` INTEGER NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+    `reword_id` INTEGER NOT NULL,
+    `sponsorship_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `sponsorship_reword` ADD CONSTRAINT `sponsorship_reword_reword_id_fkey` FOREIGN KEY (`reword_id`) REFERENCES `project_reword`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `sponsorship_reword` ADD CONSTRAINT `sponsorship_reword_sponsorship_id_fkey` FOREIGN KEY (`sponsorship_id`) REFERENCES `sponsorship`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240304130811_add_scheduled_at_column_in_project_schedule_table/migration.sql
+++ b/prisma/migrations/20240304130811_add_scheduled_at_column_in_project_schedule_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `scheduled_at` to the `project_schedule` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `project_schedule` ADD COLUMN `scheduled_at` DATETIME(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,8 @@ model User {
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
+  Project Project[]
+
   @@map(name: "user")
 }
 
@@ -36,5 +38,44 @@ model ProjectCategory {
   id   Int    @id @default(autoincrement())
   name String @db.VarChar(12)
 
+  Project Project[]
+
   @@map(name: "project_category")
+}
+
+/// 프로젝트 상태
+enum ProjectStatus {
+  REVIEW_PENDING /// 심사 대기
+  REVIEW_PASSED /// 심사 통과
+  REVIEW_FAILED /// 심사 불통과
+  PROJECT_CANCELED /// 프로젝트 취소
+  FUNDING_OPENED /// 펀딩 오픈(진행중)
+  FUNDING_SUCCESS /// 펀딩 성사
+  FUNDING_FAILURE /// 펀딩 무산
+  FUNDING_CANCELED /// 펀딩 취소
+  SETTLEMENT_COMPLETED /// 정산 완료
+  PROJECT_HALTED /// 프로젝트 중단
+
+  @@map(name: "project_status")
+}
+
+/// 프로젝트
+model Project {
+  id               Int           @id @default(autoincrement())
+  status           ProjectStatus /// 상태
+  title            String        @db.VarChar(32) /// 제목
+  summary          String        @db.VarChar(50) /// 요약
+  description      String        @db.MediumText /// 마크다운 형식 프로젝트 설명
+  thumbnail_url    String        @db.VarChar(2000) /// 대표 이미지 url
+  target_amount    BigInt        @db.BigInt /// 목표 금액
+  collected_amount BigInt        @db.BigInt /// 모인 금액
+  created_at       DateTime      @default(now())
+  updated_at       DateTime      @updatedAt
+
+  created_by    User            @relation(fields: [created_by_id], references: [id]) /// 창작자
+  created_by_id Int
+  category      ProjectCategory @relation(fields: [category_id], references: [id]) /// 카테고리
+  category_id   Int
+
+  @@map(name: "project")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,7 @@ enum ProjectStatus {
 }
 
 /// 프로젝트
+/// 창작자가 펀딩을 진행할 프로젝트에 관한 정보
 model Project {
   id               Int           @id @default(autoincrement())
   status           ProjectStatus /// 상태
@@ -96,11 +97,13 @@ enum ProjectScheduleType {
 }
 
 /// 프로젝트 스케줄
+/// 하나의 프로젝트의 진행 일정에 관한 정보
 model ProjectSchedule {
-  id         Int                 @id @default(autoincrement())
-  type       ProjectScheduleType
-  created_at DateTime            @default(now())
-  updated_at DateTime            @updatedAt
+  id           Int                 @id @default(autoincrement())
+  type         ProjectScheduleType
+  scheduled_at DateTime /// 스케줄 일시
+  created_at   DateTime            @default(now())
+  updated_at   DateTime            @updatedAt
 
   project    Project @relation(fields: [project_id], references: [id]) /// 프로젝트
   project_id Int
@@ -109,6 +112,7 @@ model ProjectSchedule {
 }
 
 /// 프로젝트 선물
+/// 사용자가 프로젝트를 후원할 경우 선택할 수 있는 선물에 관한 정보
 model ProjectReword {
   id                     Int      @id @default(autoincrement())
   title                  String   @db.VarChar(50) /// 제목
@@ -129,6 +133,7 @@ model ProjectReword {
 
 // TODO: 결제 정보 추가해야 함
 /// 프로젝트 후원
+/// 사용자가 특정 프로젝트를 후원할 경우 생성되는 정보
 model Sponsorship {
   id         Int      @id @default(autoincrement())
   created_at DateTime @default(now())
@@ -145,6 +150,7 @@ model Sponsorship {
 }
 
 /// 후원 선물 내역
+/// 한 번의 후원에서 사용자가 선택한 선물에 대한 정보
 model SponsorshipReword {
   id         Int      @id @default(autoincrement())
   count      Int /// 선물(project_reword) 개수

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,3 +30,11 @@ model User {
 
   @@map(name: "user")
 }
+
+/// 프로젝트 카테고리
+model ProjectCategory {
+  id   Int    @id @default(autoincrement())
+  name String @db.VarChar(12)
+
+  @@map(name: "project_category")
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ model Project {
   category_id   Int
 
   ProjectSchedule ProjectSchedule[] /// 스케줄(일정)
+  ProjectReword   ProjectReword[]
 
   @@map(name: "project")
 }
@@ -103,4 +104,21 @@ model ProjectSchedule {
   project_id Int
 
   @@map(name: "project_schedule")
+}
+
+/// 프로젝트 선물
+model ProjectReword {
+  id                     Int      @id @default(autoincrement())
+  title                  String   @db.VarChar(50) /// 제목
+  description            String   @db.VarChar(200) /// 설명
+  amount                 Int /// 금액
+  limit                  Int /// 후원 가능 수량
+  expected_delivery_date DateTime /// 예상 수령가능 날짜
+  created_at             DateTime @default(now())
+  updated_at             DateTime @updatedAt
+
+  project    Project @relation(fields: [project_id], references: [id]) /// 프로젝트
+  project_id Int
+
+  @@map(name: "project_reword")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,5 +77,30 @@ model Project {
   category      ProjectCategory @relation(fields: [category_id], references: [id]) /// 카테고리
   category_id   Int
 
+  ProjectSchedule ProjectSchedule[] /// 스케줄(일정)
+
   @@map(name: "project")
+}
+
+/// 프로젝트 스케줄 타입 enum
+enum ProjectScheduleType {
+  FUNDING_START_DATE /// 펀딩 시작일
+  FUNDING_DUE_DATE /// 펀딩 마감일
+  PAYMENT_DUE_DATE /// 결제 마감일
+  PAYMENT_SETTLEMENT_DATE /// 정산일
+
+  @@map(name: "project_schedule_type")
+}
+
+/// 프로젝트 스케줄
+model ProjectSchedule {
+  id         Int                 @id @default(autoincrement())
+  type       ProjectScheduleType
+  created_at DateTime            @default(now())
+  updated_at DateTime            @updatedAt
+
+  project    Project @relation(fields: [project_id], references: [id]) /// 프로젝트
+  project_id Int
+
+  @@map(name: "project_schedule")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,8 @@ model User {
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
-  Project Project[]
+  project     Project[]
+  sponsorship Sponsorship[]
 
   @@map(name: "user")
 }
@@ -38,7 +39,7 @@ model ProjectCategory {
   id   Int    @id @default(autoincrement())
   name String @db.VarChar(12)
 
-  Project Project[]
+  project Project[]
 
   @@map(name: "project_category")
 }
@@ -77,8 +78,9 @@ model Project {
   category      ProjectCategory @relation(fields: [category_id], references: [id]) /// 카테고리
   category_id   Int
 
-  ProjectSchedule ProjectSchedule[] /// 스케줄(일정)
-  ProjectReword   ProjectReword[]
+  project_schedule ProjectSchedule[] /// 스케줄(일정)
+  project_reword   ProjectReword[] /// 프로젝트 선물 리스트
+  sponsorship      Sponsorship[] /// 후원 내역
 
   @@map(name: "project")
 }
@@ -121,4 +123,19 @@ model ProjectReword {
   project_id Int
 
   @@map(name: "project_reword")
+}
+
+// TODO: 결제 정보 추가해야 함
+/// 프로젝트 후원
+model Sponsorship {
+  id         Int      @id @default(autoincrement())
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  project       Project @relation(fields: [project_id], references: [id]) /// 후원한 프로젝트
+  project_id    Int
+  created_by    User    @relation(fields: [created_by_id], references: [id]) /// 후원자
+  created_by_id Int
+
+  @@map(name: "sponsorship")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,8 @@ model ProjectReword {
   project    Project @relation(fields: [project_id], references: [id]) /// 프로젝트
   project_id Int
 
+  sponsorship_reword SponsorshipReword[] /// 후원 선물 내역
+
   @@map(name: "project_reword")
 }
 
@@ -137,5 +139,22 @@ model Sponsorship {
   created_by    User    @relation(fields: [created_by_id], references: [id]) /// 후원자
   created_by_id Int
 
+  sponsorship_reword SponsorshipReword[] /// 후원 선물 내역
+
   @@map(name: "sponsorship")
+}
+
+/// 후원 선물 내역
+model SponsorshipReword {
+  id         Int      @id @default(autoincrement())
+  count      Int /// 선물(project_reword) 개수
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  reword         ProjectReword @relation(fields: [reword_id], references: [id]) /// 후원한 선물
+  reword_id      Int
+  sponsorship    Sponsorship   @relation(fields: [sponsorship_id], references: [id]) /// 후원 내역
+  sponsorship_id Int
+
+  @@map(name: "sponsorship_reword")
 }


### PR DESCRIPTION
# 🛠 작업 구분
- [ ] api 추가, 수정, 삭제
- [x] schema 추가, 수정, 삭제
- [ ] document 추가, 수정, 삭제
- [ ] 버그 픽스

# 🔬 세부 구현사항
- 프로젝트 도메인 관련 schema 정의
  - 프로젝트 (`project`)
    - 창작자가 펀딩을 받을 프로젝트를 정의한 테이블입니다
    - 명칭을 미션이나 벤처로 바꿔볼까 고민했으나,,, 프로젝트가 제일 적합한 것 같아서 유지했습니다 🥺
  - 프로젝트 스케줄 (`project_schedule`)
    - 프로젝트의 여러 일정(펀딩 시작일, 펀딩 종료일 등)을 정의한 테이블입니다
  - 프로젝트 카테고리 (`project_category`)
    - 프로젝트는 하나의 카테고리에 포함됩니다
  - 프로젝트 선물 (`project_reword`)
    - 후원자가 프로젝트를 후원하게 될 시 선택할 수 있는 선물을 정의한 테이블입니다
  - 프로젝트 후원 (`sponsorship`)
    - 프로젝트를 후원할 경우 후원 정보를 정의한 테이블입니다
  - 후원한 선물 내역 (`sponsorship_reword`)
    - 한 번의 후원 시 여러 선물을 여러 개 선택할 수 있습니다

# 📎 문서
- [ERD](https://www.notion.so/ERD-7b2cd5bce572499281dee5eff853e569?pvs=4#0ff5798b151c43e9b74d716af2f4d9e8)
  - 영어로 된 테이블과 컬럼들이 해당 PR에 반영된 항목들입니다
