### PR TITLE
프로젝트 조회 & 수정 & 상태 수정 api, 프로젝트 스케줄 추가 api 등

### DIFF
--- a/prisma/migrations/20240326160404_update_project_schedule_table/migration.sql
+++ b/prisma/migrations/20240326160404_update_project_schedule_table/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `scheduled_at` on the `project_schedule` table. All the data in the column will be lost.
+  - You are about to drop the column `type` on the `project_schedule` table. All the data in the column will be lost.
+  - Added the required column `funding_due_date` to the `project_schedule` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `funding_start_date` to the `project_schedule` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `payment_due_date` to the `project_schedule` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `payment_settlement_date` to the `project_schedule` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `project_schedule` DROP COLUMN `scheduled_at`,
+    DROP COLUMN `type`,
+    ADD COLUMN `funding_due_date` DATETIME(3) NOT NULL,
+    ADD COLUMN `funding_start_date` DATETIME(3) NOT NULL,
+    ADD COLUMN `payment_due_date` DATETIME(3) NOT NULL,
+    ADD COLUMN `payment_settlement_date` DATETIME(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,24 +90,16 @@ model Project {
   @@map(name: "project")
 }
 
-/// 프로젝트 스케줄 타입 enum
-enum ProjectScheduleType {
-  FUNDING_START_DATE /// 펀딩 시작일
-  FUNDING_DUE_DATE /// 펀딩 마감일
-  PAYMENT_DUE_DATE /// 결제 마감일
-  PAYMENT_SETTLEMENT_DATE /// 정산일
-
-  @@map(name: "project_schedule_type")
-}
-
 /// 프로젝트 스케줄
 /// 하나의 프로젝트의 진행 일정에 관한 정보
 model ProjectSchedule {
-  id           Int                 @id @default(autoincrement())
-  type         ProjectScheduleType
-  scheduled_at DateTime /// 스케줄 일시
-  created_at   DateTime            @default(now())
-  updated_at   DateTime            @updatedAt
+  id                      Int      @id @default(autoincrement())
+  funding_start_date      DateTime /// 펀딩 시작일
+  funding_due_date        DateTime /// 펀딩 마감일
+  payment_due_date        DateTime /// 결제 마감일
+  payment_settlement_date DateTime /// 정산일
+  created_at              DateTime @default(now())
+  updated_at              DateTime @updatedAt
 
   project    Project @relation(fields: [project_id], references: [id]) /// 프로젝트
   project_id Int

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { ProjectCategoryModule } from './project-category/project-category.modul
 import { ProjectModule } from './project/project.module'
 import { LoggerMiddleware } from './common/logger'
 import { configuration } from './common/config/env'
+import { ProjectScheduleModule } from './project-schedule/project-schedule.module'
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { configuration } from './common/config/env'
     FileModule,
     ProjectCategoryModule,
     ProjectModule,
+    ProjectScheduleModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/project-category/dto/category.response.dto.ts
+++ b/src/project-category/dto/category.response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger'
 
-export class CreateCategoryResponseDto {
+export class CategoryResponseDto {
   @ApiProperty()
   id: number
 

--- a/src/project-category/dto/index.ts
+++ b/src/project-category/dto/index.ts
@@ -1,2 +1,2 @@
 export * from './create-category.request.dto'
-export * from './create-category.response.dto'
+export * from './category.response.dto'

--- a/src/project-category/project-category.controller.ts
+++ b/src/project-category/project-category.controller.ts
@@ -1,8 +1,10 @@
 import { Body, Controller, Post, UseGuards } from '@nestjs/common'
 import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger'
 import { ProjectCategoryService } from './project-category.service'
-import { CreateCategoryRequestDto, CreateCategoryResponseDto } from './dto'
+import { CreateCategoryRequestDto, CategoryResponseDto } from './dto'
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard'
+
+// TODO: 관리자만 write 가능
 
 @ApiTags('project-category')
 @Controller('project-category')
@@ -10,10 +12,9 @@ export class ProjectCategoryController {
   constructor(private readonly projectCategoryService: ProjectCategoryService) {}
 
   @Post()
-  @ApiCreatedResponse({ type: CreateCategoryResponseDto })
-  // FIXME: 어드민 권한의 사용자만 허용
+  @ApiCreatedResponse({ type: CategoryResponseDto })
   @UseGuards(JwtAuthGuard)
-  async createCategory(@Body() dto: CreateCategoryRequestDto): Promise<CreateCategoryResponseDto> {
+  async createCategory(@Body() dto: CreateCategoryRequestDto): Promise<CategoryResponseDto> {
     return await this.projectCategoryService.createCategory(dto)
   }
 }

--- a/src/project-category/project-category.module.ts
+++ b/src/project-category/project-category.module.ts
@@ -8,5 +8,6 @@ import { ProjectCategoryRepository } from './project-category.repository'
   imports: [PrismaModule],
   providers: [ProjectCategoryService, ProjectCategoryRepository],
   controllers: [ProjectCategoryController],
+  exports: [ProjectCategoryService],
 })
 export class ProjectCategoryModule {}

--- a/src/project-category/project-category.repository.ts
+++ b/src/project-category/project-category.repository.ts
@@ -1,16 +1,22 @@
 import { Injectable } from '@nestjs/common'
 import { PrismaService } from 'src/prisma/prisma.service'
-import { CreateCategoryResponseDto } from './dto'
+import { CategoryResponseDto } from './dto'
 
 @Injectable()
 export class ProjectCategoryRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(name: string): Promise<CreateCategoryResponseDto> {
-    const newCategory = await this.prisma.projectCategory.create({ data: { name } })
-    return {
-      id: newCategory.id,
-      name: newCategory.name,
-    }
+  async create(name: string): Promise<CategoryResponseDto> {
+    return await this.prisma.projectCategory.create({
+      data: { name },
+      select: { id: true, name: true },
+    })
+  }
+
+  async getOne(id: number): Promise<CategoryResponseDto> {
+    return await this.prisma.projectCategory.findUnique({
+      where: { id },
+      select: { id: true, name: true },
+    })
   }
 }

--- a/src/project-category/project-category.service.ts
+++ b/src/project-category/project-category.service.ts
@@ -1,12 +1,26 @@
-import { Injectable } from '@nestjs/common'
-import { CreateCategoryRequestDto, CreateCategoryResponseDto } from './dto'
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common'
+import { CreateCategoryRequestDto, CategoryResponseDto } from './dto'
 import { ProjectCategoryRepository } from './project-category.repository'
 
 @Injectable()
 export class ProjectCategoryService {
   constructor(private readonly projectCategoryRepository: ProjectCategoryRepository) {}
 
-  async createCategory({ name }: CreateCategoryRequestDto): Promise<CreateCategoryResponseDto> {
+  async createCategory({ name }: CreateCategoryRequestDto): Promise<CategoryResponseDto> {
     return await this.projectCategoryRepository.create(name)
+  }
+
+  async getCategory(id: number): Promise<CategoryResponseDto> {
+    if (!id) {
+      throw new ConflictException('Required project category id')
+    }
+
+    const category = await this.projectCategoryRepository.getOne(id)
+
+    if (!category) {
+      throw new NotFoundException('Not found project category')
+    }
+
+    return category
   }
 }

--- a/src/project-schedule/domain/project-schedule.ts
+++ b/src/project-schedule/domain/project-schedule.ts
@@ -1,0 +1,56 @@
+import { BadRequestException } from '@nestjs/common'
+import dayjs from 'dayjs'
+
+const setTimeToEndOfDay = (date: Date) => {
+  return dayjs(date).set('hour', 23).set('minute', 59).set('second', 59).set('millisecond', 999).toDate()
+}
+
+const ScheduleDateKeys = [
+  'funding_start_date',
+  'funding_due_date',
+  'payment_due_date',
+  'payment_settlement_date',
+] as const
+
+export class ProjectSchedule {
+  constructor(
+    readonly id: number | null,
+    readonly funding_start_date: Date,
+    readonly funding_due_date: Date,
+    readonly payment_due_date: Date,
+    readonly payment_settlement_date: Date,
+    readonly project_id: number | null,
+  ) {
+    this.funding_start_date = dayjs(funding_start_date).set('minute', 0).set('second', 0).set('millisecond', 0).toDate()
+    this.funding_due_date = setTimeToEndOfDay(funding_due_date)
+    this.payment_due_date = setTimeToEndOfDay(payment_due_date)
+    this.payment_settlement_date = setTimeToEndOfDay(payment_settlement_date)
+  }
+
+  /** 모든 날짜가 오늘 이후인지 */
+  private isAllDateAfterToday() {
+    return ScheduleDateKeys.every((key) => dayjs(this[key]).isAfter(dayjs().startOf('day')))
+  }
+
+  /** 각 Enum 순서대로 날짜가 나열되어있는지 */
+  private isAllDateOrderValid() {
+    return ScheduleDateKeys.every((key, index, arr) => {
+      if (index + 1 === arr.length) return true
+      return dayjs(this[arr[index + 1]]).isAfter(this[key])
+    })
+  }
+
+  /** 모든 일정들이 유효한 일정인지 */
+  public isAllValid(): boolean {
+    if (!this.isAllDateAfterToday()) {
+      throw new BadRequestException('All schedules must be set for today or later')
+    }
+    if (!this.isAllDateOrderValid()) {
+      throw new BadRequestException('All schedules must be listed in order')
+    }
+
+    return true
+  }
+
+  // TODO: 결제 마감일, 정산일은 관리자나 시스템만 수정 가능
+}

--- a/src/project-schedule/domain/project-schedule.ts
+++ b/src/project-schedule/domain/project-schedule.ts
@@ -1,5 +1,5 @@
 import { BadRequestException } from '@nestjs/common'
-import dayjs from 'dayjs'
+import * as dayjs from 'dayjs'
 
 const setTimeToEndOfDay = (date: Date) => {
   return dayjs(date).set('hour', 23).set('minute', 59).set('second', 59).set('millisecond', 999).toDate()

--- a/src/project-schedule/dto/create-schedule.request.dto.ts
+++ b/src/project-schedule/dto/create-schedule.request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { IsISO8601 } from 'class-validator'
+
+export class CreateScheduleRequestDto {
+  @IsISO8601()
+  @ApiProperty()
+  funding_start_date: string
+
+  @IsISO8601()
+  @ApiProperty()
+  funding_due_date: string
+}

--- a/src/project-schedule/dto/index.ts
+++ b/src/project-schedule/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './create-schedule.request.dto'
+export * from './schedule.response.dto'

--- a/src/project-schedule/dto/schedule.response.dto.ts
+++ b/src/project-schedule/dto/schedule.response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class ScheduleResponseDto {
+  @ApiProperty()
+  id: number
+
+  @ApiProperty()
+  funding_start_date: Date
+
+  @ApiProperty()
+  funding_due_date: Date
+
+  @ApiProperty()
+  payment_due_date: Date
+
+  @ApiProperty()
+  payment_settlement_date: Date
+
+  @ApiProperty()
+  project_id: number
+}

--- a/src/project-schedule/project-schedule.controller.ts
+++ b/src/project-schedule/project-schedule.controller.ts
@@ -1,6 +1,5 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common'
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger'
-import { JwtAuthGuard } from 'src/auth/jwt-auth.guard'
+import { Body, Controller, Delete, Param, ParseIntPipe, Patch, Post } from '@nestjs/common'
+import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger'
 import { ProjectScheduleService } from './project-schedule.service'
 import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
 
@@ -8,7 +7,6 @@ import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
 
 @ApiTags('project-schedule')
 @Controller()
-@UseGuards(JwtAuthGuard)
 export class ProjectScheduleController {
   constructor(private readonly scheduleService: ProjectScheduleService) {}
 
@@ -19,12 +17,6 @@ export class ProjectScheduleController {
     @Body() dto: CreateScheduleRequestDto,
   ): Promise<ScheduleResponseDto> {
     return await this.scheduleService.createSchedule(projectId, dto)
-  }
-
-  @Get('/project/schedule/:scheduleId')
-  @ApiOkResponse({ type: ScheduleResponseDto })
-  async getSchedule(@Param('scheduleId', ParseIntPipe) scheduleId: number): Promise<ScheduleResponseDto> {
-    return await this.scheduleService.getSchedule(scheduleId)
   }
 
   @Patch('/project/schedule/:scheduleId')

--- a/src/project-schedule/project-schedule.controller.ts
+++ b/src/project-schedule/project-schedule.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common'
+import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger'
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard'
+import { ProjectScheduleService } from './project-schedule.service'
+import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
+
+// TODO: 창작자만 write 가능
+
+@ApiTags('project-schedule')
+@Controller()
+@UseGuards(JwtAuthGuard)
+export class ProjectScheduleController {
+  constructor(private readonly scheduleService: ProjectScheduleService) {}
+
+  @Post('/project/:projectId/schedule')
+  @ApiCreatedResponse({ type: ScheduleResponseDto })
+  async createSchedule(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Body() dto: CreateScheduleRequestDto,
+  ): Promise<ScheduleResponseDto> {
+    return await this.scheduleService.createSchedule(projectId, dto)
+  }
+
+  @Get('/project/schedule/:scheduleId')
+  @ApiOkResponse({ type: ScheduleResponseDto })
+  async getSchedule(@Param('scheduleId', ParseIntPipe) scheduleId: number): Promise<ScheduleResponseDto> {
+    return await this.scheduleService.getSchedule(scheduleId)
+  }
+
+  @Patch('/project/schedule/:scheduleId')
+  async updateSchedule() {}
+
+  @Delete('/project/schedule/:scheduleId')
+  async deleteSchedule() {}
+}

--- a/src/project-schedule/project-schedule.module.ts
+++ b/src/project-schedule/project-schedule.module.ts
@@ -8,5 +8,6 @@ import { ProjectScheduleRepository } from './project-schedule.repository'
   imports: [PrismaModule],
   providers: [ProjectScheduleService, ProjectScheduleRepository],
   controllers: [ProjectScheduleController],
+  exports: [ProjectScheduleService],
 })
 export class ProjectScheduleModule {}

--- a/src/project-schedule/project-schedule.module.ts
+++ b/src/project-schedule/project-schedule.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common'
+import { ProjectScheduleService } from './project-schedule.service'
+import { ProjectScheduleController } from './project-schedule.controller'
+import { PrismaModule } from 'src/prisma/prisma.module'
+import { ProjectScheduleRepository } from './project-schedule.repository'
+
+@Module({
+  imports: [PrismaModule],
+  providers: [ProjectScheduleService, ProjectScheduleRepository],
+  controllers: [ProjectScheduleController],
+})
+export class ProjectScheduleModule {}

--- a/src/project-schedule/project-schedule.repository.ts
+++ b/src/project-schedule/project-schedule.repository.ts
@@ -39,9 +39,9 @@ export class ProjectScheduleRepository {
     })
   }
 
-  async getSchedule(scheduleId: number): Promise<ScheduleResponseDto> {
+  async getSchedule({ id, project_id }: { id?: number; project_id?: number }): Promise<ScheduleResponseDto> {
     return await this.prisma.projectSchedule.findUnique({
-      where: { id: scheduleId },
+      where: { id, project_id },
       select: {
         id: true,
         funding_start_date: true,

--- a/src/project-schedule/project-schedule.repository.ts
+++ b/src/project-schedule/project-schedule.repository.ts
@@ -40,7 +40,7 @@ export class ProjectScheduleRepository {
   }
 
   async getSchedule({ id, project_id }: { id?: number; project_id?: number }): Promise<ScheduleResponseDto> {
-    return await this.prisma.projectSchedule.findUnique({
+    return await this.prisma.projectSchedule.findFirst({
       where: { id, project_id },
       select: {
         id: true,

--- a/src/project-schedule/project-schedule.repository.ts
+++ b/src/project-schedule/project-schedule.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common'
+import { PrismaService } from 'src/prisma/prisma.service'
+import { ScheduleResponseDto } from './dto'
+
+@Injectable()
+export class ProjectScheduleRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(
+    projectId: number,
+    {
+      funding_start_date,
+      funding_due_date,
+      payment_due_date,
+      payment_settlement_date,
+    }: {
+      funding_start_date: string
+      funding_due_date: string
+      payment_due_date: string
+      payment_settlement_date: string
+    },
+  ): Promise<ScheduleResponseDto> {
+    return await this.prisma.projectSchedule.create({
+      data: {
+        funding_start_date,
+        funding_due_date,
+        payment_due_date,
+        payment_settlement_date,
+        project_id: projectId,
+      },
+      select: {
+        id: true,
+        funding_start_date: true,
+        funding_due_date: true,
+        payment_due_date: true,
+        payment_settlement_date: true,
+        project_id: true,
+      },
+    })
+  }
+
+  async getSchedule(scheduleId: number): Promise<ScheduleResponseDto> {
+    return await this.prisma.projectSchedule.findUnique({
+      where: { id: scheduleId },
+      select: {
+        id: true,
+        funding_start_date: true,
+        funding_due_date: true,
+        payment_due_date: true,
+        payment_settlement_date: true,
+        project_id: true,
+      },
+    })
+  }
+}

--- a/src/project-schedule/project-schedule.service.ts
+++ b/src/project-schedule/project-schedule.service.ts
@@ -1,0 +1,31 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common'
+import { ProjectScheduleRepository } from './project-schedule.repository'
+import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
+import dayjs from 'dayjs'
+
+@Injectable()
+export class ProjectScheduleService {
+  constructor(private readonly scheduleRepository: ProjectScheduleRepository) {}
+
+  async createSchedule(projectId: number, dto: CreateScheduleRequestDto): Promise<ScheduleResponseDto> {
+    return await this.scheduleRepository.create(projectId, {
+      ...dto,
+      payment_due_date: dayjs(dto.funding_due_date).add(7, 'day').toISOString(),
+      payment_settlement_date: dayjs(dto.funding_due_date).add(14, 'day').toISOString(),
+    })
+  }
+
+  async getSchedule(scheduleId: number): Promise<ScheduleResponseDto> {
+    if (!scheduleId) {
+      throw new ConflictException('Required project schedule id')
+    }
+
+    const schedule = await this.scheduleRepository.getSchedule(scheduleId)
+
+    if (!schedule) {
+      throw new NotFoundException('Not found project schedule')
+    }
+
+    return schedule
+  }
+}

--- a/src/project-schedule/project-schedule.service.ts
+++ b/src/project-schedule/project-schedule.service.ts
@@ -1,7 +1,7 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common'
 import { ProjectScheduleRepository } from './project-schedule.repository'
 import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
-import dayjs from 'dayjs'
+import * as dayjs from 'dayjs'
 
 @Injectable()
 export class ProjectScheduleService {

--- a/src/project-schedule/project-schedule.service.ts
+++ b/src/project-schedule/project-schedule.service.ts
@@ -15,12 +15,12 @@ export class ProjectScheduleService {
     })
   }
 
-  async getSchedule(scheduleId: number): Promise<ScheduleResponseDto> {
-    if (!scheduleId) {
-      throw new ConflictException('Required project schedule id')
+  async getSchedule({ id, project_id }: { id?: number; project_id?: number }): Promise<ScheduleResponseDto> {
+    if (!id && !project_id) {
+      throw new ConflictException('Required project schedule id or project id')
     }
 
-    const schedule = await this.scheduleRepository.getSchedule(scheduleId)
+    const schedule = await this.scheduleRepository.getSchedule({ id, project_id })
 
     if (!schedule) {
       throw new NotFoundException('Not found project schedule')

--- a/src/project/domain/draft-project-state.ts
+++ b/src/project/domain/draft-project-state.ts
@@ -1,6 +1,7 @@
 import { ProjectStatus } from '@prisma/client'
 import { Project } from './project'
 import { ProjectState } from './project-state'
+import { BadRequestException } from '@nestjs/common'
 
 export class DraftProjectState extends ProjectState {
   constructor(project: Project) {
@@ -13,10 +14,10 @@ export class DraftProjectState extends ProjectState {
     }
 
     if (!this.project.isAllValid()) {
-      throw new Error('Project must be valid')
+      throw new BadRequestException('Project must be valid')
     }
     if (!this.project.schedule?.isAllValid()) {
-      throw new Error('Project schedules must be valid')
+      throw new BadRequestException('Project schedules must be valid')
     }
     // TODO: reword 검사
 

--- a/src/project/domain/draft-project-state.ts
+++ b/src/project/domain/draft-project-state.ts
@@ -1,3 +1,4 @@
+import { ProjectStatus } from '@prisma/client'
 import { Project } from './project'
 import { ProjectState } from './project-state'
 
@@ -6,5 +7,19 @@ export class DraftProjectState extends ProjectState {
     super(project)
   }
 
-  // TODO: 추상 메서드 구현
+  isValidToReviewPending(): boolean {
+    if (this.project.status !== ProjectStatus.DRAFT && this.project.status !== ProjectStatus.REVIEW_FAILED) {
+      throw new Error('Unsupported status for switching to review pending')
+    }
+
+    if (!this.project.isAllValid()) {
+      throw new Error('Project must be valid')
+    }
+    if (!this.project.schedule?.isAllValid()) {
+      throw new Error('Project schedules must be valid')
+    }
+    // TODO: reword 검사
+
+    return true
+  }
 }

--- a/src/project/domain/project-state.ts
+++ b/src/project/domain/project-state.ts
@@ -1,7 +1,7 @@
 import { Project } from './project'
 
-export class ProjectState {
+export abstract class ProjectState {
   constructor(public project: Project) {}
 
-  // TODO: 추상 메서드 정의
+  abstract isValidToReviewPending(): boolean
 }

--- a/src/project/domain/project.ts
+++ b/src/project/domain/project.ts
@@ -1,6 +1,9 @@
 import { ProjectStatus } from '@prisma/client'
 import { ProjectState } from './project-state'
 import { ProjectStateFactory } from './project-state.factory'
+import { BadRequestException } from '@nestjs/common'
+import { isURL } from 'class-validator'
+import { ProjectSchedule } from 'src/project-schedule/domain/project-schedule'
 
 /**
  * Project 도메인
@@ -16,6 +19,7 @@ export class Project {
   collected_amount: bigint
   created_by_id: number
   category_id?: number
+  schedule?: ProjectSchedule
   state: ProjectState
 
   constructor(project: {
@@ -29,6 +33,7 @@ export class Project {
     collected_amount: bigint
     created_by_id: number
     category_id?: number
+    schedule?: ProjectSchedule
   }) {
     Object.keys(project).forEach((key) => (this[key] = project[key]))
     this.state = ProjectStateFactory.create(this)
@@ -36,6 +41,29 @@ export class Project {
 
   protected changeState(state: ProjectState) {
     this.state = state
+  }
+
+  public isAllValid(): boolean {
+    if (this.title.length < 1 || this.title.length > 32) {
+      throw new BadRequestException('Title must be between 1 and 32 characters')
+    }
+    if (this.summary.length < 10 || this.summary.length > 50) {
+      throw new BadRequestException('Summary must be between 10 and 50 characters')
+    }
+    if (this.description.length < 1) {
+      throw new BadRequestException('Description is required')
+    }
+    if (!isURL(this.thumbnail_url)) {
+      throw new BadRequestException('Thumbnail url is required')
+    }
+    if (this.target_amount < BigInt(500_000)) {
+      throw new BadRequestException('Target amount must be over 500,000')
+    }
+    if (!this.category_id) {
+      throw new BadRequestException('Category is required')
+    }
+
+    return true
   }
 
   // TODO: ProjectState에서 정의한 메서드 위임

--- a/src/project/domain/project.ts
+++ b/src/project/domain/project.ts
@@ -5,6 +5,13 @@ import { BadRequestException } from '@nestjs/common'
 import { isURL } from 'class-validator'
 import { ProjectSchedule } from 'src/project-schedule/domain/project-schedule'
 
+const MIN_TITLE_LENGTH = 1
+const MAX_TITLE_LENGTH = 32
+const MIN_SUMMARY_LENGTH = 10
+const MAX_SUMMARY_LENGTH = 50
+const MIN_DESCRIPTION_LENGTH = 1
+const MIN_TARGET_AMOUNT = BigInt(500_000)
+
 /**
  * Project 도메인
  */
@@ -44,19 +51,19 @@ export class Project {
   }
 
   public isAllValid(): boolean {
-    if (this.title.length < 1 || this.title.length > 32) {
+    if (this.title.length < MIN_TITLE_LENGTH || this.title.length > MAX_TITLE_LENGTH) {
       throw new BadRequestException('Title must be between 1 and 32 characters')
     }
-    if (this.summary.length < 10 || this.summary.length > 50) {
+    if (this.summary.length < MIN_SUMMARY_LENGTH || this.summary.length > MAX_SUMMARY_LENGTH) {
       throw new BadRequestException('Summary must be between 10 and 50 characters')
     }
-    if (this.description.length < 1) {
+    if (this.description.length < MIN_DESCRIPTION_LENGTH) {
       throw new BadRequestException('Description is required')
     }
     if (!isURL(this.thumbnail_url)) {
       throw new BadRequestException('Thumbnail url is required')
     }
-    if (this.target_amount < BigInt(500_000)) {
+    if (this.target_amount < MIN_TARGET_AMOUNT) {
       throw new BadRequestException('Target amount must be over 500,000')
     }
     if (!this.category_id) {

--- a/src/project/dto/index.ts
+++ b/src/project/dto/index.ts
@@ -1,3 +1,5 @@
 export * from './create-project.request.dto'
-export * from './create-project.response.dto'
+export * from './project.response.dto'
 export * from './project-summary.dto'
+export * from './update-proejct-status.request.dto'
+export * from './update-project.request.dto'

--- a/src/project/dto/project.response.dto.ts
+++ b/src/project/dto/project.response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger'
 import { ProjectStatus } from '@prisma/client'
 
-export class CreateProjectResponseDto {
+export class ProjectResponseDto {
   @ApiProperty()
   id: number
 

--- a/src/project/dto/update-proejct-status.request.dto.ts
+++ b/src/project/dto/update-proejct-status.request.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { ProjectStatus } from '@prisma/client'
+
+export class UpdateProjectStatusRequestDto {
+  @ApiProperty({ enum: ProjectStatus })
+  status: ProjectStatus
+}

--- a/src/project/dto/update-project.request.dto.ts
+++ b/src/project/dto/update-project.request.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class UpdateProjectRequestDto {
+  @ApiProperty({ required: false })
+  title?: string
+
+  @ApiProperty({ required: false })
+  summary?: string
+
+  @ApiProperty({ required: false })
+  description?: string
+
+  @ApiProperty({ required: false })
+  thumbnail_url?: string
+
+  @ApiProperty({ required: false })
+  target_amount?: bigint
+
+  @ApiProperty({ required: false })
+  category_id?: number
+}

--- a/src/project/project.builder.ts
+++ b/src/project/project.builder.ts
@@ -1,5 +1,6 @@
 import { ProjectStatus } from '@prisma/client'
 import { Project } from './domain/project'
+import { ProjectSchedule } from 'src/project-schedule/domain/project-schedule'
 
 /**
  * Project 빌더
@@ -13,6 +14,7 @@ export class ProjectBulider {
   private collected_amount: bigint
   private created_by_id: number
   private category_id?: number
+  private schedule: ProjectSchedule
 
   constructor(private status: ProjectStatus, private id?: number) {}
 
@@ -40,6 +42,11 @@ export class ProjectBulider {
     return this
   }
 
+  setSchedule(schedule: ProjectSchedule) {
+    this.schedule = schedule
+    return this
+  }
+
   build() {
     if (!this.created_by_id) {
       throw new Error('Creator Id is required')
@@ -56,6 +63,7 @@ export class ProjectBulider {
       collected_amount: this.collected_amount,
       created_by_id: this.created_by_id,
       category_id: this.category_id,
+      schedule: this.schedule,
     })
   }
 }

--- a/src/project/project.builder.ts
+++ b/src/project/project.builder.ts
@@ -18,7 +18,7 @@ export class ProjectBulider {
 
   constructor(private status: ProjectStatus, private id?: number) {}
 
-  setContents(title: string = '', summary: string = '', description: string = '', thumbnail_url: string = '') {
+  setContents(title = '', summary = '', description = '', thumbnail_url = '') {
     this.title = title
     this.summary = summary
     this.description = description
@@ -26,7 +26,7 @@ export class ProjectBulider {
     return this
   }
 
-  setAmount(target_amount: bigint = BigInt(0), collected_amount: bigint = BigInt(0)) {
+  setAmount(target_amount = BigInt(0), collected_amount = BigInt(0)) {
     this.target_amount = target_amount
     this.collected_amount = collected_amount
     return this

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -37,21 +37,19 @@ export class ProjectController {
   }
 
   @Get(':projectId')
-  async getProject(@Param('projectId', ParseIntPipe) projectId: number) {
+  async getProject(@Param('projectId', ParseIntPipe) projectId: number): Promise<ProjectResponseDto> {
     return await this.projectService.getProject(projectId)
   }
 
   @Patch(':projectId')
   @UseGuards(JwtAuthGuard)
   async updateProject(@Param('projectId', ParseIntPipe) projectId: number, @Body() dto: UpdateProjectRequestDto) {
-    const project = await this.getProject(projectId)
-
     if (typeof dto.category_id === 'number') {
       const category = await this.categoryService.getCategory(dto.category_id)
-      return await this.projectService.updateProject(project.id, { ...dto, category_id: category.id })
+      return await this.projectService.updateProject(projectId, { ...dto, category_id: category.id })
     }
 
-    return await this.projectService.updateProject(project.id, dto)
+    return await this.projectService.updateProject(projectId, dto)
   }
 
   @Patch(':projectId/status')

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -1,20 +1,32 @@
-import { Body, Controller, Post, UseGuards, Req, Get, Query } from '@nestjs/common'
+import { Body, Controller, Post, UseGuards, Req, Get, Query, Patch, Param, ParseIntPipe } from '@nestjs/common'
 import { Request } from 'express'
 import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger'
-import { CreateProjectRequestDto, CreateProjectResponseDto, ProjectSummaryDto } from './dto'
+import {
+  CreateProjectRequestDto,
+  ProjectResponseDto,
+  ProjectSummaryDto,
+  UpdateProjectRequestDto,
+  UpdateProjectStatusRequestDto,
+} from './dto'
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard'
 import { ProjectService } from './project.service'
 import { ApiPaginatedResponse, PageRequestDto, PageResponseDto } from 'src/common/pagination'
+import { ProjectCategoryService } from 'src/project-category/project-category.service'
+
+// TODO: 창작자만 write 가능
 
 @ApiTags('project')
 @Controller('project')
-@UseGuards(JwtAuthGuard)
 export class ProjectController {
-  constructor(private readonly projectService: ProjectService) {}
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly categoryService: ProjectCategoryService,
+  ) {}
 
   @Post()
-  @ApiCreatedResponse({ type: CreateProjectResponseDto })
-  async createProject(@Body() dto: CreateProjectRequestDto, @Req() req: Request): Promise<CreateProjectResponseDto> {
+  @ApiCreatedResponse({ type: ProjectResponseDto })
+  @UseGuards(JwtAuthGuard)
+  async createProject(@Body() dto: CreateProjectRequestDto, @Req() req: Request): Promise<ProjectResponseDto> {
     return await this.projectService.createProject(dto, req.user.userId)
   }
 
@@ -22,5 +34,33 @@ export class ProjectController {
   @ApiPaginatedResponse(ProjectSummaryDto)
   async getProjects(@Query() dto: PageRequestDto): Promise<PageResponseDto<ProjectSummaryDto>> {
     return await this.projectService.getProjects(dto)
+  }
+
+  @Get(':projectId')
+  async getProject(@Param('projectId', ParseIntPipe) projectId: number) {
+    return await this.projectService.getProject(projectId)
+  }
+
+  @Patch(':projectId')
+  @UseGuards(JwtAuthGuard)
+  async updateProject(@Param('projectId', ParseIntPipe) projectId: number, @Body() dto: UpdateProjectRequestDto) {
+    const project = await this.getProject(projectId)
+
+    if (typeof dto.category_id === 'number') {
+      const category = await this.categoryService.getCategory(dto.category_id)
+      return await this.projectService.updateProject(project.id, { ...dto, category_id: category.id })
+    }
+
+    return await this.projectService.updateProject(project.id, dto)
+  }
+
+  @Patch(':projectId/status')
+  @ApiOkResponse({ type: ProjectResponseDto })
+  @UseGuards(JwtAuthGuard)
+  async updateProjectStatus(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Query() { status }: UpdateProjectStatusRequestDto,
+  ): Promise<ProjectResponseDto> {
+    return await this.projectService.updateProjectStatus({ projectId, status })
   }
 }

--- a/src/project/project.module.ts
+++ b/src/project/project.module.ts
@@ -3,9 +3,11 @@ import { ProjectController } from './project.controller'
 import { ProjectService } from './project.service'
 import { PrismaModule } from 'src/prisma/prisma.module'
 import { ProjectRepository } from './project.repository'
+import { ProjectCategoryModule } from 'src/project-category/project-category.module'
+import { ProjectScheduleModule } from 'src/project-schedule/project-schedule.module'
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, ProjectCategoryModule, ProjectScheduleModule],
   controllers: [ProjectController],
   providers: [ProjectService, ProjectRepository],
 })

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,19 +1,30 @@
-import { ConflictException, Injectable } from '@nestjs/common'
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common'
 import { ProjectStatus } from '@prisma/client'
-import { CreateProjectRequestDto, CreateProjectResponseDto, ProjectSummaryDto } from './dto'
+import {
+  CreateProjectRequestDto,
+  ProjectResponseDto,
+  ProjectSummaryDto,
+  UpdateProjectRequestDto,
+  UpdateProjectStatusRequestDto,
+} from './dto'
 import { ProjectRepository } from './project.repository'
 import { ProjectBulider } from './project.builder'
 import { Project } from './domain/project'
 import { PageRequestDto, PageResponseDto } from 'src/common/pagination'
+import { ProjectScheduleService } from 'src/project-schedule/project-schedule.service'
+import { ProjectSchedule } from 'src/project-schedule/domain/project-schedule'
 
 @Injectable()
 export class ProjectService {
-  constructor(private readonly projectRepository: ProjectRepository) {}
+  constructor(
+    private readonly projectRepository: ProjectRepository,
+    private readonly scheduleService: ProjectScheduleService,
+  ) {}
 
   async createProject(
     { title, summary, description, thumbnail_url, target_amount, category_id }: CreateProjectRequestDto,
     created_by_id: Project['created_by_id'],
-  ): Promise<CreateProjectResponseDto> {
+  ): Promise<ProjectResponseDto> {
     const count = await this.projectRepository.getDraftProjectCount(created_by_id)
 
     if (count >= 5) {
@@ -33,7 +44,7 @@ export class ProjectService {
   async getProjects(dto: PageRequestDto): Promise<PageResponseDto<ProjectSummaryDto>> {
     const { page, size } = dto
 
-    const [items, total] = await this.projectRepository.getProjectsWithTotal({
+    const [items, total] = await this.projectRepository.getManyWithTotal({
       skip: dto.getSkip(),
       take: dto.getTake(),
     })
@@ -47,5 +58,56 @@ export class ProjectService {
       size,
       items,
     }
+  }
+
+  async getProject(id: number): Promise<ProjectResponseDto> {
+    if (!id) {
+      throw new ConflictException('Required project id')
+    }
+
+    const project = await this.projectRepository.getOne(id)
+
+    if (!project) {
+      throw new NotFoundException('Not found project')
+    }
+
+    return project
+  }
+
+  /**
+   * 프로젝트 상태 변경
+   */
+  async updateProjectStatus({ projectId, status }: { projectId: number } & UpdateProjectStatusRequestDto) {
+    const _project = await this.getProject(projectId)
+    const _schedule = await this.scheduleService.getSchedule({ project_id: projectId })
+    const schedule = new ProjectSchedule(
+      _schedule.id,
+      _schedule.funding_start_date,
+      _schedule.funding_due_date,
+      _schedule.payment_due_date,
+      _schedule.payment_settlement_date,
+      _schedule.project_id,
+    )
+    const project = new ProjectBulider(_project.status, _project.id)
+      .setContents(_project.title, _project.summary, _project.description, _project.thumbnail_url)
+      .setAmount(_project.target_amount)
+      .setCreatedById(_project.created_by_id)
+      .setCategoryId(_project.category_id)
+      .setSchedule(schedule)
+      .build()
+
+    if (status === ProjectStatus.REVIEW_PENDING) {
+      if (!project.state.isValidToReviewPending()) {
+        throw new Error('Project is not valid to review pending status')
+      }
+      return await this.projectRepository.updateStatus(projectId, status)
+    }
+
+    // TODO: 구현
+    throw new Error('Method not implemented')
+  }
+
+  async updateProject(projectId: number, dto: UpdateProjectRequestDto) {
+    return await this.projectRepository.update(projectId, dto)
   }
 }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -21,6 +21,9 @@ export class ProjectService {
     private readonly scheduleService: ProjectScheduleService,
   ) {}
 
+  /**
+   * 프로젝트 생성
+   */
   async createProject(
     { title, summary, description, thumbnail_url, target_amount, category_id }: CreateProjectRequestDto,
     created_by_id: Project['created_by_id'],
@@ -41,6 +44,9 @@ export class ProjectService {
     return await this.projectRepository.create(project)
   }
 
+  /**
+   * 프로젝트 목록 조회
+   */
   async getProjects(dto: PageRequestDto): Promise<PageResponseDto<ProjectSummaryDto>> {
     const { page, size } = dto
 
@@ -60,6 +66,9 @@ export class ProjectService {
     }
   }
 
+  /**
+   * 프로젝트 단일 조회
+   */
   async getProject(id: number): Promise<ProjectResponseDto> {
     if (!id) {
       throw new ConflictException('Required project id')
@@ -107,7 +116,16 @@ export class ProjectService {
     throw new Error('Method not implemented')
   }
 
+  /**
+   * 프로젝트 수정
+   */
   async updateProject(projectId: number, dto: UpdateProjectRequestDto) {
+    const project = await this.getProject(projectId)
+
+    if (project.status !== ProjectStatus.DRAFT && project.status !== ProjectStatus.REVIEW_FAILED) {
+      throw new BadRequestException('Only draft or review failed projects can be updated')
+    }
+
     return await this.projectRepository.update(projectId, dto)
   }
 }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common'
 import { ProjectStatus } from '@prisma/client'
 import {
   CreateProjectRequestDto,
@@ -98,7 +98,7 @@ export class ProjectService {
 
     if (status === ProjectStatus.REVIEW_PENDING) {
       if (!project.state.isValidToReviewPending()) {
-        throw new Error('Project is not valid to review pending status')
+        throw new BadRequestException('Project is not valid to review pending status')
       }
       return await this.projectRepository.updateStatus(projectId, status)
     }


### PR DESCRIPTION
# 🛠 작업 구분

- [x] api 추가, 수정, 삭제
- [x] schema 추가, 수정, 삭제
- [x] document 추가, 수정, 삭제
- [ ] 기타 모듈 추가, 수정, 삭제
- [ ] 버그 픽스

# 🔬 세부 구현사항

- project_schedule schema 변경
  - 기존의 구조는 일정을 추가하거나 변경한 시각을 추적할 수 있는 장점이 있었지만 하나의 프로젝트에 4개의 일정이 존재해야 한다는 무결성을 지키기 힘들 것 같아 구조를 변경하게 되었습니다
- api 추가
  - project schedule 추가 api
  - project 단일 조회 api
  - project 수정 api
  - project 상태 수정 api
    - status 수정 시 체크해야 하는 항목이 많아 api를 분리하게 되었습니다
    - draft -> 심사대기로 전환하는 로직만 구현되어있습니다 ,,
- service 추가
  - project category 단일 조회
  - project schedule 단일 조회

# 📎 문서

-
