### PR TITLE
프로젝트 심사 api 구현, 사용자 역할 체크 guard 구현 등

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "ts-loader": "^9.2.3",
         "ts-node": "^10.0.0",
         "tsconfig-paths": "4.1.1",
-        "typescript": "^4.7.4"
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9212,16 +9212,16 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uid": {
@@ -16510,9 +16510,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true
     },
     "uid": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "4.1.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.4.5"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/prisma/migrations/20240415162725_update_status_column_in_project_table/migration.sql
+++ b/prisma/migrations/20240415162725_update_status_column_in_project_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - The values [REVIEW_PASSED,REVIEW_FAILED,PROJECT_HALTED] on the enum `project_status` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `project` MODIFY `status` ENUM('DRAFT', 'REVIEW_PENDING', 'REVIEW_APPROVED', 'REVIEW_REJECTED', 'PROJECT_CANCELED', 'TO_BE_RELEASED', 'FUNDING_OPENED', 'FUNDING_SUCCESS', 'FUNDING_FAILURE', 'FUNDING_CANCELED', 'SETTLEMENT_COMPLETED') NOT NULL DEFAULT 'DRAFT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,17 +49,17 @@ model ProjectCategory {
 
 /// 프로젝트 상태
 enum ProjectStatus {
-  DRAFT /// 프로젝트 심사 제출 전
+  DRAFT /// 작성중
   REVIEW_PENDING /// 심사 대기
-  REVIEW_PASSED /// 심사 통과
-  REVIEW_FAILED /// 심사 불통과
+  REVIEW_APPROVED /// 심사 승인
+  REVIEW_REJECTED /// 심사 반려
   PROJECT_CANCELED /// 프로젝트 취소
+  TO_BE_RELEASED /// 공개 예정
   FUNDING_OPENED /// 펀딩 오픈(진행중)
   FUNDING_SUCCESS /// 펀딩 성사
   FUNDING_FAILURE /// 펀딩 무산
   FUNDING_CANCELED /// 펀딩 취소
   SETTLEMENT_COMPLETED /// 정산 완료
-  PROJECT_HALTED /// 프로젝트 중단
 
   @@map(name: "project_status")
 }
@@ -128,6 +128,7 @@ model ProjectReword {
 }
 
 // TODO: 결제 정보 추가해야 함
+// TODO: 후원 상태 추가해야 함
 /// 프로젝트 후원
 /// 사용자가 특정 프로젝트를 후원할 경우 생성되는 정보
 model Sponsorship {

--- a/src/project-category/project-category.controller.ts
+++ b/src/project-category/project-category.controller.ts
@@ -3,8 +3,7 @@ import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger'
 import { ProjectCategoryService } from './project-category.service'
 import { CreateCategoryRequestDto, CategoryResponseDto } from './dto'
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard'
-
-// TODO: 관리자만 write 가능
+import { RolesGuard } from '../users/roles.guard'
 
 @ApiTags('project-category')
 @Controller('project-category')
@@ -13,7 +12,7 @@ export class ProjectCategoryController {
 
   @Post()
   @ApiCreatedResponse({ type: CategoryResponseDto })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard('ADMIN'))
   async createCategory(@Body() dto: CreateCategoryRequestDto): Promise<CategoryResponseDto> {
     return await this.projectCategoryService.createCategory(dto)
   }

--- a/src/project-schedule/project-schedule.controller.ts
+++ b/src/project-schedule/project-schedule.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, ParseIntPipe, Patch, Post } from '@nestjs/common'
+import { Body, Controller, Param, ParseIntPipe, Patch, Post } from '@nestjs/common'
 import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger'
 import { ProjectScheduleService } from './project-schedule.service'
 import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
@@ -21,7 +21,4 @@ export class ProjectScheduleController {
 
   @Patch('/project/schedule/:scheduleId')
   async updateSchedule() {}
-
-  @Delete('/project/schedule/:scheduleId')
-  async deleteSchedule() {}
 }

--- a/src/project-schedule/project-schedule.service.ts
+++ b/src/project-schedule/project-schedule.service.ts
@@ -2,10 +2,24 @@ import { ConflictException, Injectable, NotFoundException } from '@nestjs/common
 import { ProjectScheduleRepository } from './project-schedule.repository'
 import { CreateScheduleRequestDto, ScheduleResponseDto } from './dto'
 import * as dayjs from 'dayjs'
+import { ProjectSchedule } from './domain/project-schedule'
 
 @Injectable()
 export class ProjectScheduleService {
   constructor(private readonly scheduleRepository: ProjectScheduleRepository) {}
+
+  async createScheduleDomain({ projectId }): Promise<ProjectSchedule> {
+    const { id, funding_start_date, funding_due_date, payment_due_date, payment_settlement_date, project_id } =
+      await this.getSchedule({ project_id: projectId })
+    return new ProjectSchedule(
+      id,
+      funding_start_date,
+      funding_due_date,
+      payment_due_date,
+      payment_settlement_date,
+      project_id,
+    )
+  }
 
   async createSchedule(projectId: number, dto: CreateScheduleRequestDto): Promise<ScheduleResponseDto> {
     return await this.scheduleRepository.create(projectId, {

--- a/src/project/domain/draft-project-state.ts
+++ b/src/project/domain/draft-project-state.ts
@@ -20,11 +20,7 @@ export class DraftProjectState extends ProjectState {
     return true
   }
 
-  isValidToReviewApproved(): boolean {
-    throw new Error('Not supported method')
-  }
-
-  isValidToReviewRejected(): boolean {
+  isValidToReview(): boolean {
     throw new Error('Not supported method')
   }
 }

--- a/src/project/domain/draft-project-state.ts
+++ b/src/project/domain/draft-project-state.ts
@@ -9,18 +9,22 @@ export class DraftProjectState extends ProjectState {
   }
 
   isValidToReviewPending(): boolean {
-    if (this.project.status !== ProjectStatus.DRAFT && this.project.status !== ProjectStatus.REVIEW_FAILED) {
-      throw new Error('Unsupported status for switching to review pending')
+    if (this.project.status !== ProjectStatus.DRAFT && this.project.status !== ProjectStatus.REVIEW_REJECTED) {
+      throw new BadRequestException('Unsupported status for switching to review pending')
     }
 
-    if (!this.project.isAllValid()) {
-      throw new BadRequestException('Project must be valid')
+    if (!this.isValid()) {
+      throw new BadRequestException('All elements of the project must be valid')
     }
-    if (!this.project.schedule?.isAllValid()) {
-      throw new BadRequestException('Project schedules must be valid')
-    }
-    // TODO: reword 검사
 
     return true
+  }
+
+  isValidToReviewApproved(): boolean {
+    throw new Error('Not supported method')
+  }
+
+  isValidToReviewRejected(): boolean {
+    throw new Error('Not supported method')
   }
 }

--- a/src/project/domain/project-state.factory.ts
+++ b/src/project/domain/project-state.factory.ts
@@ -2,12 +2,19 @@ import { ProjectStatus } from '@prisma/client'
 import { Project } from './project'
 import { DraftProjectState } from './draft-project-state'
 import { ProjectState } from './project-state'
+import { ReviewPendingProjectState } from './review-pending-project-state'
 
 export class ProjectStateFactory {
   static create(project: Project): ProjectState {
     switch (project.status) {
       case ProjectStatus.DRAFT:
         return new DraftProjectState(project)
+      case ProjectStatus.REVIEW_PENDING:
+        return new ReviewPendingProjectState(project)
+      case ProjectStatus.REVIEW_APPROVED:
+        throw new Error("Unsupported status to create 'ProjectState'")
+      case ProjectStatus.REVIEW_REJECTED:
+        throw new Error("Unsupported status to create 'ProjectState'")
       // TODO: 추가 state 구현
       default:
         throw new Error("Unsupported status to create 'ProjectState'")

--- a/src/project/domain/project-state.ts
+++ b/src/project/domain/project-state.ts
@@ -1,7 +1,23 @@
 import { Project } from './project'
+import { BadRequestException } from '@nestjs/common'
 
 export abstract class ProjectState {
-  constructor(public project: Project) {}
+  protected constructor(public project: Project) {}
+
+  /** 프로젝트의 모든 구성요소가 유효한지 검사하는 함수 */
+  protected isValid(): boolean {
+    if (!this.project.isAllValid()) {
+      throw new BadRequestException('Project must be valid')
+    }
+    if (!this.project.schedule?.isAllValid()) {
+      throw new BadRequestException('Project schedules must be valid')
+    }
+    // TODO: reword 검사
+
+    return true
+  }
 
   abstract isValidToReviewPending(): boolean
+  abstract isValidToReviewApproved(): boolean
+  abstract isValidToReviewRejected(): boolean
 }

--- a/src/project/domain/project-state.ts
+++ b/src/project/domain/project-state.ts
@@ -18,6 +18,5 @@ export abstract class ProjectState {
   }
 
   abstract isValidToReviewPending(): boolean
-  abstract isValidToReviewApproved(): boolean
-  abstract isValidToReviewRejected(): boolean
+  abstract isValidToReview(): boolean
 }

--- a/src/project/domain/review-pending-project-state.ts
+++ b/src/project/domain/review-pending-project-state.ts
@@ -1,0 +1,38 @@
+import { ProjectStatus } from '@prisma/client'
+import { Project } from './project'
+import { ProjectState } from './project-state'
+import { BadRequestException } from '@nestjs/common'
+
+export class ReviewPendingProjectState extends ProjectState {
+  constructor(project: Project) {
+    super(project)
+  }
+
+  isValidToReviewPending(): boolean {
+    throw new Error('Not supported method')
+  }
+
+  isValidToReviewApproved(): boolean {
+    if (this.project.status !== ProjectStatus.REVIEW_PENDING) {
+      throw new BadRequestException('Unsupported status for switching to review approved')
+    }
+
+    if (!this.isValid()) {
+      throw new BadRequestException('All elements of the project must be valid')
+    }
+
+    return true
+  }
+
+  isValidToReviewRejected(): boolean {
+    if (this.project.status !== ProjectStatus.REVIEW_PENDING) {
+      throw new BadRequestException('Unsupported status for switching to review approved')
+    }
+
+    if (!this.isValid()) {
+      throw new BadRequestException('All elements of the project must be valid')
+    }
+
+    return true
+  }
+}

--- a/src/project/domain/review-pending-project-state.ts
+++ b/src/project/domain/review-pending-project-state.ts
@@ -12,21 +12,9 @@ export class ReviewPendingProjectState extends ProjectState {
     throw new Error('Not supported method')
   }
 
-  isValidToReviewApproved(): boolean {
+  isValidToReview(): boolean {
     if (this.project.status !== ProjectStatus.REVIEW_PENDING) {
-      throw new BadRequestException('Unsupported status for switching to review approved')
-    }
-
-    if (!this.isValid()) {
-      throw new BadRequestException('All elements of the project must be valid')
-    }
-
-    return true
-  }
-
-  isValidToReviewRejected(): boolean {
-    if (this.project.status !== ProjectStatus.REVIEW_PENDING) {
-      throw new BadRequestException('Unsupported status for switching to review approved')
+      throw new BadRequestException('Unsupported status for switching to review approved or rejected')
     }
 
     if (!this.isValid()) {

--- a/src/project/dto/project.response.dto.ts
+++ b/src/project/dto/project.response.dto.ts
@@ -1,6 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger'
 import { ProjectStatus } from '@prisma/client'
 
+class ProjectCategory {
+  @ApiProperty()
+  id: number
+
+  @ApiProperty()
+  name: string
+}
+
+class User {
+  @ApiProperty()
+  id: number
+
+  @ApiProperty()
+  nickname: string
+}
+
 export class ProjectResponseDto {
   @ApiProperty()
   id: number
@@ -27,8 +43,8 @@ export class ProjectResponseDto {
   collected_amount: bigint
 
   @ApiProperty()
-  created_by_id: number
+  created_by: User
 
   @ApiProperty({ nullable: true })
-  category_id: number | null
+  category: ProjectCategory | null
 }

--- a/src/project/dto/review-project.request.dto.ts
+++ b/src/project/dto/review-project.request.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { ProjectStatus } from '@prisma/client'
+
+export class ReviewProjectRequestDto {
+  @ApiProperty({ enum: [ProjectStatus.REVIEW_APPROVED, ProjectStatus.REVIEW_REJECTED] })
+  result: typeof ProjectStatus.REVIEW_APPROVED | typeof ProjectStatus.REVIEW_REJECTED
+}

--- a/src/project/project.builder.ts
+++ b/src/project/project.builder.ts
@@ -5,7 +5,7 @@ import { ProjectSchedule } from 'src/project-schedule/domain/project-schedule'
 /**
  * Project 빌더
  */
-export class ProjectBulider {
+export class ProjectBuilder {
   private title: string
   private summary: string
   private description: string

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -62,7 +62,10 @@ export class ProjectController {
   async updateProject(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Body() dto: UpdateProjectRequestDto,
+    @Req() req: Request,
   ): Promise<ProjectResponseDto> {
+    await this.projectService.checkIsCreator({ projectId, userId: req.user.userId })
+
     if (typeof dto.category_id === 'number') {
       const category = await this.categoryService.getCategory(dto.category_id)
       return await this.projectService.updateProject(projectId, { ...dto, category_id: category.id })
@@ -80,7 +83,10 @@ export class ProjectController {
   async updateProjectStatus(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Query() { status }: UpdateProjectStatusRequestDto,
+    @Req() req: Request,
   ): Promise<ProjectResponseDto> {
+    await this.projectService.checkIsCreator({ projectId, userId: req.user.userId })
+
     return await this.projectService.updateProjectStatus({ projectId, status })
   }
 

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -48,6 +48,7 @@ export class ProjectController {
    * 프로젝트 단일 조회
    */
   @Get(':projectId')
+  @ApiOkResponse({ type: ProjectResponseDto })
   async getProject(@Param('projectId', ParseIntPipe) projectId: number): Promise<ProjectResponseDto> {
     return await this.projectService.getProject(projectId)
   }
@@ -57,7 +58,11 @@ export class ProjectController {
    */
   @Patch(':projectId')
   @UseGuards(JwtAuthGuard)
-  async updateProject(@Param('projectId', ParseIntPipe) projectId: number, @Body() dto: UpdateProjectRequestDto) {
+  @ApiOkResponse({ type: ProjectResponseDto })
+  async updateProject(
+    @Param('projectId', ParseIntPipe) projectId: number,
+    @Body() dto: UpdateProjectRequestDto,
+  ): Promise<ProjectResponseDto> {
     if (typeof dto.category_id === 'number') {
       const category = await this.categoryService.getCategory(dto.category_id)
       return await this.projectService.updateProject(projectId, { ...dto, category_id: category.id })
@@ -70,8 +75,8 @@ export class ProjectController {
    * 프로젝트 상태 변경
    */
   @Patch(':projectId/status')
-  @ApiOkResponse({ type: ProjectResponseDto })
   @UseGuards(JwtAuthGuard)
+  @ApiOkResponse({ type: ProjectResponseDto })
   async updateProjectStatus(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Query() { status }: UpdateProjectStatusRequestDto,
@@ -83,8 +88,8 @@ export class ProjectController {
    * 프로젝트 심사(승인 또는 거절)
    */
   @Patch(':projectId/review')
-  @ApiOkResponse({ type: ProjectResponseDto })
   @UseGuards(JwtAuthGuard, RolesGuard('ADMIN'))
+  @ApiOkResponse({ type: ProjectResponseDto })
   async reviewProject(
     @Param('projectId', ParseIntPipe) projectId: number,
     @Query() { result }: ReviewProjectRequestDto,

--- a/src/project/project.repository.ts
+++ b/src/project/project.repository.ts
@@ -100,6 +100,13 @@ export class ProjectRepository {
     })
   }
 
+  async getCreatorId(projectId: number) {
+    return this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: { created_by_id: true },
+    })
+  }
+
   async update(
     id: number,
     { title, summary, description, thumbnail_url, target_amount, category_id }: UpdateProjectRequestDto,

--- a/src/project/project.repository.ts
+++ b/src/project/project.repository.ts
@@ -42,7 +42,7 @@ export class ProjectRepository {
       category_id: category_id,
     }
 
-    const newProject = await this.prisma.project.create({
+    return this.prisma.project.create({
       data: project,
       select: {
         id: true,
@@ -53,12 +53,10 @@ export class ProjectRepository {
         thumbnail_url: true,
         target_amount: true,
         collected_amount: true,
-        created_by_id: true,
-        category_id: true,
+        created_by: { select: { id: true, nickname: true } },
+        category: { select: { id: true, name: true } },
       },
     })
-
-    return newProject
   }
 
   async getManyWithTotal({ skip, take }: { skip: number; take: number }): Promise<[ProjectSummaryDto[], number]> {
@@ -85,7 +83,7 @@ export class ProjectRepository {
   }
 
   async getOne(id: number): Promise<ProjectResponseDto> {
-    return await this.prisma.project.findUnique({
+    return this.prisma.project.findUnique({
       where: { id },
       select: {
         id: true,
@@ -96,8 +94,8 @@ export class ProjectRepository {
         thumbnail_url: true,
         target_amount: true,
         collected_amount: true,
-        created_by_id: true,
-        category_id: true,
+        created_by: { select: { id: true, nickname: true } },
+        category: { select: { id: true, name: true } },
       },
     })
   }
@@ -106,7 +104,7 @@ export class ProjectRepository {
     id: number,
     { title, summary, description, thumbnail_url, target_amount, category_id }: UpdateProjectRequestDto,
   ): Promise<ProjectResponseDto> {
-    return await this.prisma.project.update({
+    return this.prisma.project.update({
       where: { id },
       data: { title, summary, description, thumbnail_url, target_amount, category_id },
       select: {
@@ -118,14 +116,14 @@ export class ProjectRepository {
         thumbnail_url: true,
         target_amount: true,
         collected_amount: true,
-        created_by_id: true,
-        category_id: true,
+        created_by: { select: { id: true, nickname: true } },
+        category: { select: { id: true, name: true } },
       },
     })
   }
 
   async updateStatus(id: number, status: ProjectStatus): Promise<ProjectResponseDto> {
-    return await this.prisma.project.update({
+    return this.prisma.project.update({
       where: { id },
       data: { status },
       select: {
@@ -137,8 +135,8 @@ export class ProjectRepository {
         thumbnail_url: true,
         target_amount: true,
         collected_amount: true,
-        created_by_id: true,
-        category_id: true,
+        created_by: { select: { id: true, nickname: true } },
+        category: { select: { id: true, name: true } },
       },
     })
   }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common'
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
 import { ProjectStatus } from '@prisma/client'
 import {
   CreateProjectRequestDto,
@@ -20,6 +26,20 @@ export class ProjectService {
     private readonly projectRepository: ProjectRepository,
     private readonly scheduleService: ProjectScheduleService,
   ) {}
+
+  async checkIsCreator({ projectId, userId }: { projectId: number; userId: number }): Promise<void> {
+    const project = await this.projectRepository.getCreatorId(projectId)
+
+    if (!project) {
+      throw new NotFoundException('Not found project')
+    }
+
+    if (project.created_by_id !== userId) {
+      throw new ForbiddenException('Only creator can be access')
+    }
+
+    return
+  }
 
   async createProjectDomain({ projectId }: { projectId: number }): Promise<Project> {
     const { id, status, title, summary, description, thumbnail_url, target_amount, created_by, category } =

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -22,15 +22,15 @@ export class ProjectService {
   ) {}
 
   async createProjectDomain({ projectId }: { projectId: number }): Promise<Project> {
-    const { id, status, title, summary, description, thumbnail_url, target_amount, created_by_id, category_id } =
+    const { id, status, title, summary, description, thumbnail_url, target_amount, created_by, category } =
       await this.getProject(projectId)
     const schedule = await this.scheduleService.createScheduleDomain({ projectId })
 
     return new ProjectBuilder(status, id)
       .setContents(title, summary, description, thumbnail_url)
       .setAmount(target_amount)
-      .setCreatedById(created_by_id)
-      .setCategoryId(category_id)
+      .setCreatedById(created_by.id)
+      .setCategoryId(category?.id)
       .setSchedule(schedule)
       .build()
   }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -8,11 +8,11 @@ import {
   UpdateProjectStatusRequestDto,
 } from './dto'
 import { ProjectRepository } from './project.repository'
-import { ProjectBulider } from './project.builder'
+import { ProjectBuilder } from './project.builder'
 import { Project } from './domain/project'
 import { PageRequestDto, PageResponseDto } from 'src/common/pagination'
 import { ProjectScheduleService } from 'src/project-schedule/project-schedule.service'
-import { ProjectSchedule } from 'src/project-schedule/domain/project-schedule'
+import { ReviewProjectRequestDto } from './dto/review-project.request.dto'
 
 @Injectable()
 export class ProjectService {
@@ -20,6 +20,20 @@ export class ProjectService {
     private readonly projectRepository: ProjectRepository,
     private readonly scheduleService: ProjectScheduleService,
   ) {}
+
+  async createProjectDomain({ projectId }: { projectId: number }): Promise<Project> {
+    const { id, status, title, summary, description, thumbnail_url, target_amount, created_by_id, category_id } =
+      await this.getProject(projectId)
+    const schedule = await this.scheduleService.createScheduleDomain({ projectId })
+
+    return new ProjectBuilder(status, id)
+      .setContents(title, summary, description, thumbnail_url)
+      .setAmount(target_amount)
+      .setCreatedById(created_by_id)
+      .setCategoryId(category_id)
+      .setSchedule(schedule)
+      .build()
+  }
 
   /**
    * 프로젝트 생성
@@ -34,7 +48,7 @@ export class ProjectService {
       throw new ConflictException('A maximum of 5 draft projects can be created')
     }
 
-    const project = new ProjectBulider(ProjectStatus.DRAFT)
+    const project = new ProjectBuilder(ProjectStatus.DRAFT)
       .setContents(title, summary, description, thumbnail_url)
       .setAmount(target_amount)
       .setCreatedById(created_by_id)
@@ -87,33 +101,35 @@ export class ProjectService {
    * 프로젝트 상태 변경
    */
   async updateProjectStatus({ projectId, status }: { projectId: number } & UpdateProjectStatusRequestDto) {
-    const _project = await this.getProject(projectId)
-    const _schedule = await this.scheduleService.getSchedule({ project_id: projectId })
-    const schedule = new ProjectSchedule(
-      _schedule.id,
-      _schedule.funding_start_date,
-      _schedule.funding_due_date,
-      _schedule.payment_due_date,
-      _schedule.payment_settlement_date,
-      _schedule.project_id,
-    )
-    const project = new ProjectBulider(_project.status, _project.id)
-      .setContents(_project.title, _project.summary, _project.description, _project.thumbnail_url)
-      .setAmount(_project.target_amount)
-      .setCreatedById(_project.created_by_id)
-      .setCategoryId(_project.category_id)
-      .setSchedule(schedule)
-      .build()
+    const project = await this.createProjectDomain({ projectId })
 
-    if (status === ProjectStatus.REVIEW_PENDING) {
-      if (!project.state.isValidToReviewPending()) {
-        throw new BadRequestException('Project is not valid to review pending status')
+    switch (status) {
+      case ProjectStatus.REVIEW_PENDING: {
+        if (!project.state.isValidToReviewPending()) {
+          throw new BadRequestException('Project is not valid to review pending status')
+        }
+        break
       }
-      return await this.projectRepository.updateStatus(projectId, status)
+
+      case ProjectStatus.REVIEW_APPROVED: {
+        if (!project.state.isValidToReviewApproved()) {
+          throw new BadRequestException('Project is not valid to review approved status')
+        }
+        break
+      }
+
+      case ProjectStatus.REVIEW_REJECTED: {
+        if (!project.state.isValidToReviewRejected()) {
+          throw new BadRequestException('Project is not valid to review rejected status')
+        }
+        break
+      }
+      // TODO: 구현
+      default:
+        throw new Error('Method not implemented')
     }
 
-    // TODO: 구현
-    throw new Error('Method not implemented')
+    return await this.projectRepository.updateStatus(projectId, status)
   }
 
   /**
@@ -122,10 +138,23 @@ export class ProjectService {
   async updateProject(projectId: number, dto: UpdateProjectRequestDto) {
     const project = await this.getProject(projectId)
 
-    if (project.status !== ProjectStatus.DRAFT && project.status !== ProjectStatus.REVIEW_FAILED) {
-      throw new BadRequestException('Only draft or review failed projects can be updated')
+    if (project.status !== ProjectStatus.DRAFT && project.status !== ProjectStatus.REVIEW_REJECTED) {
+      throw new BadRequestException('Only draft or review rejected projects can be updated')
     }
 
     return await this.projectRepository.update(projectId, dto)
+  }
+
+  /**
+   * 프로젝트 심사 승인 또는 거절
+   */
+  async reviewProject(projectId: number, { result }: ReviewProjectRequestDto) {
+    const project = await this.getProject(projectId)
+
+    if (project.status !== ProjectStatus.REVIEW_PENDING) {
+      throw new BadRequestException('Only projects in review pending status can be reviewed')
+    }
+
+    return await this.updateProjectStatus({ projectId, status: result })
   }
 }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -131,19 +131,14 @@ export class ProjectService {
         break
       }
 
-      case ProjectStatus.REVIEW_APPROVED: {
-        if (!project.state.isValidToReviewApproved()) {
-          throw new BadRequestException('Project is not valid to review approved status')
+      case ProjectStatus.REVIEW_APPROVED:
+      case ProjectStatus.REVIEW_REJECTED: {
+        if (!project.state.isValidToReview()) {
+          throw new BadRequestException('Project is not valid to review approved or rejected status')
         }
         break
       }
 
-      case ProjectStatus.REVIEW_REJECTED: {
-        if (!project.state.isValidToReviewRejected()) {
-          throw new BadRequestException('Project is not valid to review rejected status')
-        }
-        break
-      }
       // TODO: 구현
       default:
         throw new Error('Method not implemented')

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -37,8 +37,6 @@ export class ProjectService {
     if (project.created_by_id !== userId) {
       throw new ForbiddenException('Only creator can be access')
     }
-
-    return
   }
 
   async createProjectDomain({ projectId }: { projectId: number }): Promise<Project> {

--- a/src/users/roles.guard.ts
+++ b/src/users/roles.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, Injectable, mixin, Type } from '@nestjs/common'
+import { UserRole } from '@prisma/client'
+import { JwtDto } from '../auth/dto'
+
+export const RolesGuard = (...roles: UserRole[]): Type<CanActivate> => {
+  @Injectable()
+  class RolesGuardMixin implements CanActivate {
+    canActivate(context: ExecutionContext): boolean {
+      if (!roles) {
+        return true
+      }
+      const request = context.switchToHttp().getRequest()
+      const user: JwtDto = request.user
+
+      console.log(request.user)
+
+      return user && roles.includes(user.userRole)
+    }
+  }
+
+  return mixin(RolesGuardMixin)
+}

--- a/src/users/roles.guard.ts
+++ b/src/users/roles.guard.ts
@@ -12,8 +12,6 @@ export const RolesGuard = (...roles: UserRole[]): Type<CanActivate> => {
       const request = context.switchToHttp().getRequest()
       const user: JwtDto = request.user
 
-      console.log(request.user)
-
       return user && roles.includes(user.userRole)
     }
   }


### PR DESCRIPTION
# 🛠 작업 구분

- [x] api 추가, 수정, 삭제
- [x] schema 추가, 수정, 삭제
- [x] document 추가, 수정, 삭제
- [x] 기타 모듈 추가, 수정, 삭제
- [ ] 버그 픽스

# 🔬 세부 구현사항

- project schema - status enum 수정
- [사용자 역할 체크 guard 정의](https://www.notion.so/guard-1a02e976eb1c457e8456af3ad50b4b94?pvs=4)
- [프로젝트 심사 api 구현](https://www.notion.so/api-3a8ba5294ee64634a8e8c8604d79ab77?pvs=4)
  - 프로젝트의 상태를 심사승인 또는 심사거절로 변경
- 기타
  - 관리자만 프로젝트 카테고리 생성 api 접근 가능하도록 제한
  - 창작자만 프로젝트 수정 및 상태변경 api 접근 가능하도록 제한

# 📎 문서

-
